### PR TITLE
検出されたパラメーターをブロックで編集できるようにした

### DIFF
--- a/lib/external_parameter_finder.rb
+++ b/lib/external_parameter_finder.rb
@@ -61,17 +61,22 @@ class ExternalParameterFinder
 
   def initialize(predefined_variables)
     @param_names = []
-    @params = []
     @stored_variables = []
     @predefined_variables = GLOBAL_OBJECTS + predefined_variables
   end
 
-  def parse yaml
+  def parse yaml, &block
     store_values YAML.safe_load yaml
+    params = []
     @param_names.each do |param_name|
-      @params.push(name: param_name, paramName: param_name, description: '', type: 'Text', value: '')
+      if block_given?
+        element = yield(param_name)
+      else
+        element = { name: param_name, paramName: param_name, description: '', type: 'Text', value: '' }
+      end
+      params.push(element)
     end
-    @params
+    params
   end
 
   def store_values parsed_yaml

--- a/spec/external_parameter_finder_spec.rb
+++ b/spec/external_parameter_finder_spec.rb
@@ -18,14 +18,35 @@ predefined_parameters = RESERVED_VARIABLES + STANDARD_LIBRARIES
 RSpec.describe ExternalParameterFinder do
 
   context "when parse wantedly scout dry run yaml" do 
-    it "detects username, password, url, limit, automation_id, webhookUrl" do 
-      parser = ExternalParameterFinder.new(predefined_parameters)
-      yaml = File.open('./spec/resource/wantedly_scout_dry_run.yaml')
-      params = parser.parse yaml
-      expect(params.map { |el| el[:paramName] }).to eq([
-        "username", "password", "url", "limit", "automation_id", "webhookUrl"
-      ])
+    context "when block not given" do 
+      it "detects username, password, url, limit, automation_id, webhookUrl" do 
+        parser = ExternalParameterFinder.new(predefined_parameters)
+        yaml = File.open('./spec/resource/wantedly_scout_dry_run.yaml')
+        params = parser.parse yaml
+        expect(params.map { |el| el[:paramName] }).to eq([
+          "username", "password", "url", "limit", "automation_id", "webhookUrl"
+        ])
+      end
     end
+
+    context "when block is given" do 
+      it "detects username, password, url, limit, automation_id, webhookUrl processed with a given block" do 
+        parser = ExternalParameterFinder.new(predefined_parameters)
+        yaml = File.open('./spec/resource/wantedly_scout_dry_run.yaml')
+        params = parser.parse yaml do |param_name|
+          { hoge: param_name }
+        end
+        expect(params).to eq([
+          { hoge: "username"}, 
+          { hoge: "password"},
+          { hoge: "url" },
+          { hoge: "limit"},
+          { hoge: "automation_id"},
+          { hoge: "webhookUrl"},
+        ])
+      end
+    end
+
   end
 
   context "when parse wantedly scout send scout yaml" do 


### PR DESCRIPTION
# このPRは何か？

検出した変数を任意の形に修正したいニーズに対応

# 何をしたか？

`ExternalParameterFinder#parse` にブロックを渡せるようにした。

```rb 
parser = ExternalParameterFinder.new(predefined_parameters)
yaml = File.open('./spec/resource/wantedly_scout_dry_run.yaml')
params = parser.parse yaml do |param_name|
  { hoge: param_name }
end

#=> これが得られる
[{ hoge: "username"}, 
{ hoge: "password"},
{ hoge: "url" },
{ hoge: "limit"},
{ hoge: "automation_id"},
{ hoge: "webhookUrl"}]
```